### PR TITLE
bump dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,10 @@
 click
 stups-cli-support>=1.1.20
 stups-piu>=1.1.16
-stups-senza>=2.1.104
+stups-senza>=2.1.138
 stups-zign>=1.1.31
-stups-pierone>=1.1.32
+stups-pierone>=1.1.42
 stups-fullstop>=1.1.31
-stups-kio>=0.1.20
+stups-kio>=0.1.22
 zalando-aws-cli>=1.2.4.22
-zalando-kubectl>=1.10.4.47
+zalando-kubectl>=1.13.5.74


### PR DESCRIPTION
Require latest packages (this allows people to use `pip3 install --upgrade` without extra flags like `--upgrade-strategy=eager`)